### PR TITLE
took out show because I only need to see all items, not just one.

### DIFF
--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -8,13 +8,13 @@ class Api::ItemsController < ApiController
     render json: items
   end
 
-  def show
-    list = current_user.lists.find(params[:list_id])
-    item = list.items.find(params[:id])
-    render json: item
-  rescue ActiveRecord::RecordNotFound
-    render json: {}, status: :not_found
-  end
+  # def show
+  #   list = current_user.lists.find(params[:list_id])
+  #   item = list.items.find(params[:id])
+  #   render json: item
+  # rescue ActiveRecord::RecordNotFound
+  #   render json: {}, status: :not_found
+  # end
 
   def create
     list = current_user.lists.find(params[:list_id])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     end
 
     resources :lists, only: [] do
-      resources :items, only: [:create, :update, :destroy, :index]
+      resources :items, except: [:new, :edit, :show]
     end
 
   end


### PR DESCRIPTION
I took out `show` from items because I want to simply show all the todos. Perhaps if I added another feature that would allow you to make notes on an item, or do something else, then the show can be put back. I just commented out `show` instead of deleting it altogether.